### PR TITLE
Fix bugs and add --maximum-level and --minimum-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,33 @@ python3 -m src.main --auto-run 10 --grammar
 Project CLI helper :
 
 ```
-usage: python3 -m src.main [-h] (--auto-run AUTO_RUN_COUNT | --simple-run URL) [--vocabulary | --grammar] [--debug | --no-debug]
-                           [--headless | --no-headless] [--profile PROFILE]
+usage: python3 -m src.main [-h] (--auto-run AUTO_RUN_COUNT | --simple-run URL)
+                           [--vocabulary | --grammar] [--debug | --no-debug]
+                           [--headless | --no-headless] [--cache | --no-cache]
+                           [--profile PROFILE] [--minimum-level {A1,A2,B1,B2,C1,C2}]
+                           [--maximum-level {A1,A2,B1,B2,C1,C2}]
 
 automatically execute some go fluent activities.
 
 options:
   -h, --help            show this help message and exit
   --auto-run AUTO_RUN_COUNT
-                        the amount of activities to do for the month (e.g. only does 2 if you already did 8).
+                        the amount of activities to do for the month (e.g. only does 2 if
+                        you already did 8).
   --simple-run URL      the URL of the activity to solve.
   --vocabulary          Do the vocabulary activities.
   --grammar             Do the grammar activities
   --debug, --no-debug   Enable the debug mode. Shows more logs messages in the terminal.
   --headless, --no-headless
-                        Run the firefox instance in headless mode (meaning the window won't show).
+                        Run the firefox instance in headless mode (meaning the window won't
+                        show).
+  --cache, --no-cache   Enable the cache system. If enabled, the program will store the
+                        done activities in a file.
   --profile PROFILE     The name of the credentials profile stored in the .env file.
+  --minimum-level {A1,A2,B1,B2,C1,C2}
+                        Minimum level of the activity (default: A1)
+  --maximum-level {A1,A2,B1,B2,C1,C2}
+                        Maximum level of the activity (default: C2)
 ```
 
 Two main runners are set up, you can either automatically execute the auto run mode where the count of done activities

--- a/src/classes/scraper.py
+++ b/src/classes/scraper.py
@@ -44,6 +44,8 @@ class Scraper:
         username: str,
         password: str,
         cache: bool,
+        minimum_level: str | None = None,
+        maximum_level: str | None = None,
     ):
         self.driver: Optional[Firefox] = None
         self.is_headless = is_headless
@@ -51,6 +53,8 @@ class Scraper:
         self.password = password
         self.logger = logger
         self.cache = cache
+        self.minimum_level = minimum_level
+        self.maximum_level = maximum_level
 
         self.logged_in = False
 
@@ -300,7 +304,6 @@ class Scraper:
         """Retrieve the list of all the done activities"""
         url = "https://esaip.gofluent.com/app/training"
         if self.driver.current_url != url:
-            print("url is different")
             self.driver.get(url)
 
         locator = SELECTORS["TRAINING"]["CONTAINER"]
@@ -382,7 +385,7 @@ class Scraper:
             map(lambda activity1: activity1.url, cached_activities)
         )
 
-        activities_urls = get_urls_from_activities_container(html)
+        activities_urls = get_urls_from_activities_container(html, self.minimum_level, self.maximum_level)
         activities_urls = list(
             filter(
                 lambda url1: not (url1 in cached_activities_url)

--- a/src/classes/scraper.py
+++ b/src/classes/scraper.py
@@ -52,6 +52,8 @@ class Scraper:
         self.logger = logger
         self.cache = cache
 
+        self.logged_in = False
+
         self.setup_session()
 
     def wait_for_element(
@@ -115,7 +117,11 @@ class Scraper:
 
     def login(self, redirect: Optional[str] = None):
         """Log in the user to the GoFluent website"""
-        if self.is_logged_in():
+
+        # when using --simple-run JSESSIONID can't be found
+        # so added logged_in attribute to keep track of whether or not
+        # we completed the login process
+        if self.is_logged_in() or self.logged_in:
             return
 
         self.logger.info("Logging in to the GoFluent portal.")
@@ -179,7 +185,14 @@ class Scraper:
         )
         submit_button.click()
 
+        # wait for dashboard to appear
+        self.wait_for_element(
+            SELECTORS["DASHBOARD"]["LOGO"],
+            "'Password' redirection did not work",
+        )
+
         self.logger.info("Successfully logged in to Go Fluent.")
+        self.logged_in = True
 
     @logged_in
     def select_tab(self, tab: str):
@@ -287,6 +300,7 @@ class Scraper:
         """Retrieve the list of all the done activities"""
         url = "https://esaip.gofluent.com/app/training"
         if self.driver.current_url != url:
+            print("url is different")
             self.driver.get(url)
 
         locator = SELECTORS["TRAINING"]["CONTAINER"]

--- a/src/main.py
+++ b/src/main.py
@@ -88,6 +88,22 @@ def get_parser():
         help="The name of the credentials profile stored in the .env file.",
     )
 
+    parser.add_argument(
+        "--minimum-level",
+        default=None,
+        required=False,
+        choices=["A1", "A2", "B1", "B2", "C1", "C2"],
+        help="Minimum level of the activity (default: A1)",
+    )
+
+    parser.add_argument(
+        "--maximum-level",
+        default=None,
+        required=False,
+        choices=["A1", "A2", "B1", "B2", "C1", "C2"],
+        help="Maximum level of the activity (default: C2)",
+    )
+
     return parser
 
 
@@ -140,6 +156,8 @@ def main():
                 username=username,
                 password=password,
                 cache=args.cache,
+                minimum_level=args.minimum_level,
+                maximum_level=args.maximum_level
             )
             runner.execute()
         else:

--- a/src/runners/auto_run.py
+++ b/src/runners/auto_run.py
@@ -17,6 +17,8 @@ class AutoRun:
         username: str,
         password: str,
         cache: bool,
+        minimum_level: str | None = None,
+        maximum_level: str | None = None,
     ):
         self.auto_run_count = auto_run_count
         self.is_vocabulary = is_vocabulary
@@ -25,6 +27,8 @@ class AutoRun:
         self.password = password
         self.logger = logger
         self.cache = cache
+        self.minimum_level = minimum_level
+        self.maximum_level = maximum_level
 
     def execute(self):
         """Auto-run method, retrieving the auto-run count property from the cli, retrieving the amount of done activities,
@@ -35,6 +39,8 @@ class AutoRun:
             username=self.username,
             password=self.password,
             cache=self.cache,
+            minimum_level=self.minimum_level,
+            maximum_level=self.maximum_level,
         )
 
         self.logger.info("Retrieving the count of done activities for this month.")

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -205,17 +205,35 @@ def get_fill_gaps_block_question_as_text(question_html: str):
     return soup.text.strip() + "\n" + answers_as_txt
 
 
-def get_urls_from_activities_container(container_html: str):
+def get_urls_from_activities_container(container_html: str, minimum_level: str | None = None, maximum_level: str | None = None):
     """Get the activities as list[Activiy] from the vocabulary page activities container"""
     soup = BeautifulSoup(container_html, features="html.parser")
+
+    level_mapping = {
+        "A1" : 1,
+        "A2" : 2,
+        "B1" : 3,
+        "B2" : 4,
+        "C1" : 5,
+        "C2" : 6,
+    }
 
     activities = []
 
     for activity in soup.select("li.ResourcesList__item"):
         container = activity.select_one(".resource-link")
         done = activity.select_one("div.resource-link__done-icon svg")
-        # title = activity.select_one("div.resource-link__title")
+        level = activity.select_one(".resource-link__tags").text.split("-")
 
+        # skip if the activity's level is too high
+        if maximum_level and level_mapping[level[-1]] > level_mapping[maximum_level]:
+            continue
+
+        # skip if the activity's level is too low
+        if minimum_level and level_mapping[level[0]] < level_mapping[minimum_level]:
+            continue
+
+        # add to todo if not already done
         if not done:
             activities.append(f"https://esaip.gofluent.com{container.attrs['href']}")
 


### PR DESCRIPTION
- Fixed bugs for `--simple-run` and `--auto-run` that prevented the program from successfully running
- Added `--maximum-level` and `--minimum--level` to be able to choose which level of activity you want to do.

```sh
$ python3 -m src.main -h
usage: python3 -m src.main [-h] (--auto-run AUTO_RUN_COUNT | --simple-run URL)
                           [--vocabulary | --grammar] [--debug | --no-debug]
                           [--headless | --no-headless] [--cache | --no-cache]
                           [--profile PROFILE] [--minimum-level {A1,A2,B1,B2,C1,C2}]
                           [--maximum-level {A1,A2,B1,B2,C1,C2}]

automatically execute some go fluent activities.

options:
  -h, --help            show this help message and exit
  --auto-run AUTO_RUN_COUNT
                        the amount of activities to do for the month (e.g. only does 2 if
                        you already did 8).
  --simple-run URL      the URL of the activity to solve.
  --vocabulary          Do the vocabulary activities.
  --grammar             Do the grammar activities
  --debug, --no-debug   Enable the debug mode. Shows more logs messages in the terminal.
  --headless, --no-headless
                        Run the firefox instance in headless mode (meaning the window won't
                        show).
  --cache, --no-cache   Enable the cache system. If enabled, the program will store the
                        done activities in a file.
  --profile PROFILE     The name of the credentials profile stored in the .env file.
  --minimum-level {A1,A2,B1,B2,C1,C2}
                        Minimum level of the activity (default: A1)
  --maximum-level {A1,A2,B1,B2,C1,C2}
                        Maximum level of the activity (default: C2)
```
